### PR TITLE
Update wiring_digital.cpp

### DIFF
--- a/cores/arduino/wiring_digital.cpp
+++ b/cores/arduino/wiring_digital.cpp
@@ -49,7 +49,7 @@ static GPIO_TypeDef* gpioRegister(uint8_t gpio)
 static uint8_t gpioPin(uint8_t gpio, pin_size_t pin)
 {
     if(gpio == 0) {
-        return pin;
+        return pin + 1;
     } else if(gpio == 2) {
         return pin - 2;
     } else {


### PR DESCRIPTION
Fix gpioPin when gpio == 0, Pin must be "pin + 1" for pin A1 and A2 - Hardware tests

Only for reference of naming. Pin A0 does not exists.

![image](https://github.com/AlexanderMandera/arduino-wch32v003/assets/44167689/4392d1f8-643d-4deb-b55e-a53756774b8b)